### PR TITLE
Minor tweaks to improve experience on slow iPads

### DIFF
--- a/src/select.css
+++ b/src/select.css
@@ -127,12 +127,6 @@
     white-space: nowrap;
 }
 
-.ui-select-bootstrap .ui-select-choices-row>a:hover, .ui-select-bootstrap .ui-select-choices-row>a:focus {
-    text-decoration: none;
-    color: #262626;
-    background-color: #f5f5f5;
-}
-
 .ui-select-bootstrap .ui-select-choices-row.active>a {
     color: #fff;
     text-decoration: none;

--- a/src/select.js
+++ b/src/select.js
@@ -304,7 +304,8 @@
     };
 
     ctrl.isActive = function(itemScope) {
-      return ctrl.open && ctrl.items.indexOf(itemScope[ctrl.itemProperty]) === ctrl.activeIndex;
+      var index = ctrl.items.indexOf(itemScope[ctrl.itemProperty]);
+      return ctrl.open && index === ctrl.activeIndex && index > -1;
     };
 
     ctrl.isDisabled = function(itemScope) {


### PR DESCRIPTION
- Remove hover css styles, which are overridden by 'active' class anyway
- Fix isActive check so items loading after opening select aren't all highlighted
